### PR TITLE
Make sure length isn't set before using default

### DIFF
--- a/main.c
+++ b/main.c
@@ -111,7 +111,7 @@ int main(int argc, char **argv)
 
 	if ((!limit) && (SPCtime))
 		limit = SPCtime;
-	else
+	else if (!limit)
 		limit = 60;
 
 	printf("Time (seconds):      %i\n", limit);


### PR DESCRIPTION
`if` should be `else if`, or else there's a logical error within the parameter check: That is, if both limit and SPCtime are not set, limit will be set to 60, even if the user has provided the track length missing in the SPC file itself via the `-t` parameter.