### PR TITLE
Fix filename separator detection

### DIFF
--- a/main.c
+++ b/main.c
@@ -158,7 +158,10 @@ int main(int argc, char **argv)
 			break;
 	for (; i > 0; i--)
 		if (fn[i] == '.')
+		{
 			strcpy(&fn[i + 1], "it");
+			break;
+		}
 	if (ITWrite(fn))
 		printf("Error: failed to write %s.\n", fn);
 	else


### PR DESCRIPTION
The problem is that it continues looking for `'.'` and trims the rest of the path as it would be a file extension.

So instead of 
`~/Downloads/snesmusic.org/btbm/btbm-01.it`
it was writing to
`~/Downloads/snesmusic.it`


