### PR TITLE
Add install instructions for FreeBSD

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,13 @@ You need cmake.
 
 > mkdir b && cd b && cmake .. && make
 
+Installing
+==========
+
+FreeBSD
+-------
+> pkg install spc2it
+
 Running
 =======
 


### PR DESCRIPTION
A FreeBSD port has been created (https://svnweb.freebsd.org/ports/head/audio/spc2it/). Add instructions on how to install the package.